### PR TITLE
new output in cloudposse: transfer_id

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -5,7 +5,7 @@ output "id" {
 
 output "transfer_id" {
   description = "The id of the Transfer Server"
-  value       = module.this.enabled ? aws_transfer_server.default.id : null
+  value       = module.this.enabled ? aws_transfer_server.default.*.id : null
 }
 
 output "transfer_endpoint" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,11 @@ output "id" {
   value       = module.this.enabled ? module.this.id : null
 }
 
+output "transfer_id" {
+  description = "The id of the Transfer Server"
+  value       = module.this.enabled ? aws_transfer_server.default.id : null
+}
+
 output "transfer_endpoint" {
   description = "The endpoint of the Transfer Server"
   value       = module.this.enabled ? join("", aws_transfer_server.default.*.endpoint) : null

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,9 +3,9 @@ output "id" {
   value       = module.this.enabled ? module.this.id : null
 }
 
-output "transfer_id" {
-  description = "The id of the Transfer Server"
-  value       = module.this.enabled ? aws_transfer_server.default.*.id : null
+output "vpc_endpoint_id" {
+  description = "The id of the vpc endpoint"
+  value       = module.this.enabled && var.vpc_id != null ? aws_transfer_server.default.*.id.endpoint_details[0].vpc_endpoint_id : null
 }
 
 output "transfer_endpoint" {


### PR DESCRIPTION
## what
* New outpuput transfer_id in order to get aws server transfer to use in other resources.

## why
* I wanted to create a new route53 record from my vpc endpoint dns, so if I able to get the transfer id I can navigate until get dns name.


